### PR TITLE
Fixed bug in determining when to call filters

### DIFF
--- a/lib/rack/rpc/server.rb
+++ b/lib/rack/rpc/server.rb
@@ -72,10 +72,9 @@ module Rack; module RPC
     end
 
     def callable?(method)
-      return true if options.empty?
-      return true if !options[:only].nil? && options[:only].include?(method)
-      return false if !options[:except].nil? && options[:except].include?(method)
-      true
+      options.empty? ||
+      (!options[:only].nil? && options[:only].include?(method)) ||
+      (!options[:except].nil? && !options[:except].include?(method))
     end
   end
 

--- a/spec/fixtures/fake_rpc_server_with_filters.rb
+++ b/spec/fixtures/fake_rpc_server_with_filters.rb
@@ -1,10 +1,11 @@
 class FakeRPCServerWithFilters < Rack::RPC::Server
-  attr_accessor :test_method_one_called, :test_method_two_called
+  attr_accessor :test_method_one_called, :test_method_two_called, :test_method_three_called
 
   def initialize(options = {}, &block)
     super(options, &block)
     @test_method_one_called = false
     @test_method_two_called = false
+    @test_method_three_called = false
   end
 
   def test_method_one
@@ -18,4 +19,10 @@ class FakeRPCServerWithFilters < Rack::RPC::Server
     'test_method_two'
   end
   rpc 'fakerpcserverwithfilters.test_method_two' => :test_method_two
+
+  def test_method_three
+    @test_method_three_called = true
+    'three'
+  end
+  rpc 'fakerpcserverwithfilters.test_method_three' => :test_method_three
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -148,8 +148,11 @@ describe Rack::RPC::Server do
           @server.before_method_one_called.should be_true
           @server.test_method_one_called.should be_true
           @server.test_method_one_called = false
+          @server.before_method_one_called = false
           @server.test_method_two
           @server.test_method_one_called.should be_false
+          @server.before_method_one_called.should be_false
+          @server.test_method_two_called.should be_true
         end
 
         it "should only execute the method if the method name is in the options array" do
@@ -168,6 +171,10 @@ describe Rack::RPC::Server do
           @server.test_method_two
           @server.test_method_two_called.should be_true
           @server.before_method_general_called.should be_true
+          @server.before_method_general_called = false
+          @server.test_method_three
+          @server.before_method_general_called.should be_false
+          @server.test_method_three_called.should be_true
         end
       end
     end
@@ -209,14 +216,17 @@ describe Rack::RPC::Server do
           @server.after_method_one_called = false
           @server.test_method_one_called = false
           @server.test_method_two
+          @server.after_method_one_called.should be_false
           @server.test_method_one_called.should be_false
-          @server.test_method_one_called.should be_false
+          @server.test_method_two_called.should be_true
         end
 
+        # FIXME
         it "should only execute the method if the method is in the only options array" do
           class AfterFilterOnlyArrayOptionsMethodSuccess < FakeRPCServerWithFilters
             after_filter :after_method_general, :only => [:test_method_one, :test_method_two]
             attr_accessor :after_method_general_called
+
             def after_method_general
               @after_method_general_called = true
               true
@@ -230,6 +240,10 @@ describe Rack::RPC::Server do
           @server.test_method_two
           @server.after_method_general_called.should be_true
           @server.test_method_two_called.should be_true
+          @server.after_method_general_called = false
+          @server.test_method_three
+          @server.test_method_three_called.should be_true
+          @server.after_method_general_called.should be_false
         end
       end
 
@@ -315,8 +329,11 @@ describe Rack::RPC::Server do
           @server.after_method_one_called.should be_true
           @server.test_method_one_called.should be_true
           @server.test_method_one_called = false
+          @server.after_method_one_called = false
           @server.test_method_two
           @server.test_method_one_called.should be_false
+          @server.after_method_one_called.should be_false
+          @server.test_method_two_called.should be_true
         end
 
         it "should only execute the method if the method name is in the options array" do
@@ -335,6 +352,9 @@ describe Rack::RPC::Server do
           @server.test_method_two
           @server.test_method_two_called.should be_true
           @server.after_method_general_called.should be_true
+          @server.after_method_general_called = false
+          @server.test_method_three
+          @server.after_method_general_called.should be_false
         end
       end
     end


### PR DESCRIPTION
The :only filter wasn't properly handled in the previous version.  This has been updated.
