### PR TITLE
Provide access to the current request object in RPC methods

### DIFF
--- a/lib/rack/rpc/endpoint/jsonrpc.rb
+++ b/lib/rack/rpc/endpoint/jsonrpc.rb
@@ -22,6 +22,7 @@ class Rack::RPC::Endpoint
       # @param  [Rack::Request] request
       # @return [Rack::Response]
       def execute(request)
+        @server.request = request # Store the request so it can be accessed from the server methods
         request_body = request.body.read
         request_body.force_encoding(Encoding::UTF_8) if request_body.respond_to?(:force_encoding) # Ruby 1.9+
         Rack::Response.new([process(request_body)], 200, {

--- a/lib/rack/rpc/endpoint/xmlrpc.rb
+++ b/lib/rack/rpc/endpoint/xmlrpc.rb
@@ -18,6 +18,7 @@ class Rack::RPC::Endpoint
       # @param  [Rack::RPC::Server] server
       # @param  [Hash{Symbol => Object}] options
       def initialize(server, options = {})
+        @server = server
         super()
         add_multicall     unless options[:multicall]     == false
         add_introspection unless options[:introspection] == false
@@ -31,6 +32,7 @@ class Rack::RPC::Endpoint
       # @param  [Rack::Request] request
       # @return [Rack::Response]
       def execute(request)
+        @server.request = request # Store the request so it can be accessed from the server methods
         request_body = request.body.read
         request_body.force_encoding(Encoding::UTF_8) if request_body.respond_to?(:force_encoding) # Ruby 1.9+
         Rack::Response.new([process(request_body)], 200, {

--- a/lib/rack/rpc/server.rb
+++ b/lib/rack/rpc/server.rb
@@ -40,6 +40,9 @@ module Rack; module RPC
     # @return [Hash]
     attr_reader :options
 
+    # @return Rack::Request
+    attr_accessor :request
+
     ##
     # @param  [Hash] options
     def initialize(options = {}, &block)

--- a/spec/fixtures/fake_rpc_server.rb
+++ b/spec/fixtures/fake_rpc_server.rb
@@ -1,10 +1,15 @@
-  class FakeRPCServer < Rack::RPC::Server
-    def initialize(options = {}, &block)
-      super(options, &block)
-    end
-
-    def test
-      'ok'
-    end
-    rpc 'fakerpcserver.test' => :test
+class FakeRPCServer < Rack::RPC::Server
+  def initialize(options = {}, &block)
+    super(options, &block)
   end
+
+  def test
+    'ok'
+  end
+  rpc 'fakerpcserver.test' => :test
+
+  def test_env
+    request.params['test']
+  end
+  rpc 'fakerpcserver.test_env' => :test_env
+end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -6,6 +6,12 @@ describe Rack::RPC::Server do
     FakeRPCServer.rpc['fakerpcserver.some_unknown_method'].should == nil
   end
 
+  it "has access to the request object in the rpc methods" do
+    post "/rpc?test=test", {},  Factory.valid_json_request(:method => 'fakerpcserver.test_env')
+    response = JSON.parse(last_response.body)
+    response['result'].should == 'test'
+  end
+
   describe "before filters" do
     describe "with a given method name" do
       describe "and no options" do


### PR DESCRIPTION
This commit gives us access to the current request object inside RPC methods.
