### PR TITLE
resolve conflicts with builder (~> 3.1)

### DIFF
--- a/rack-rpc.gemspec
+++ b/rack-rpc.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version      = '>= 1.9.2'
   gem.requirements               = []
-  gem.add_runtime_dependency     'builder',   '~> 2.1'
+  gem.add_runtime_dependency     'builder',   '>= 2.1'
   gem.add_runtime_dependency     'rack',      '~> 1.5'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'json',      '~> 1.7'


### PR DESCRIPTION
Unable to activate activemodel-4.1.4, because builder-2.1.2 conflicts with builder (~> 3.1) (Gem::LoadError)
